### PR TITLE
Fix Prototype Pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,11 @@ function extend(target, source) {
   var value;
 
   for (var key in source) {
+
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      return target;
+    }
+
     value = source[key];
 
     if (Array.isArray(value)) {


### PR DESCRIPTION
This package is vulnerable to prototype pollution in the ```extend``` method. 

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as _proto_, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.


Fixed by avoiding setting magical attributes.
